### PR TITLE
fix FsFile copy constructor

### DIFF
--- a/src/FsFile.cpp
+++ b/src/FsFile.cpp
@@ -26,7 +26,8 @@
 #include "FsFile.h"
 //-----------------------------------------------------------------------------
 FsFile::FsFile(const FsFile& from) {
-  close();
+  m_fFile = nullptr;
+  m_xFile = nullptr;
   if (from.m_fFile) {
     m_fFile = new (m_fileMem) FatFile;
     *m_fFile = *from.m_fFile;


### PR DESCRIPTION
Don't close() in the copy constructor. When the copy constructor is called, m_fFile and m_xFile can contain garbage.